### PR TITLE
Fix rfplayer component intialization

### DIFF
--- a/custom_components/rfplayer/__init__.py
+++ b/custom_components/rfplayer/__init__.py
@@ -305,8 +305,6 @@ async def async_setup_entry(hass, entry):
                             "FREQ H "+str(options.get(CONF_FREQ_H,0)),
                             "LEDACTIVITY "+str(int(options.get(CONF_LEDACTIVITY,True) == True)),
                             "RFLINK "+str(int(options.get(CONF_RFLINK,True) == True)),
-                            "RFLINK H "+str(int(options.get(CONF_RFLINK,True) == True)),
-                            "RFLINK L "+str(int(options.get(CONF_RFLINK,True) == True)),
                             "STATUS JSON"
                         ]
             },


### PR DESCRIPTION
"RFLINK H" and "RFLINK V" are invalid and prevent the initialization of the component.

Fixes half of the #11 bug report.