### PR TITLE
Use the name of the parameters to prevent mistakes in send_command_ack call

### DIFF
--- a/custom_components/rfplayer/__init__.py
+++ b/custom_components/rfplayer/__init__.py
@@ -129,8 +129,8 @@ async def async_setup_entry(hass, entry):
         """Send Rfplayer command."""
         _LOGGER.debug("Rfplayer send command for %s", str(call.data))
         if not await hass.data[DOMAIN][RFPLAYER_PROTOCOL].send_command_ack(
-            call.data[CONF_PROTOCOL],
-            call.data[CONF_COMMAND],
+            protocol=call.data[CONF_PROTOCOL],
+            command=call.data[CONF_COMMAND],
             device_address=call.data.get(CONF_DEVICE_ADDRESS),
             device_id=call.data.get(CONF_DEVICE_ID),
         ):


### PR DESCRIPTION
This is good in all cases and as send_command_ack takes named-parameter is easy to achieve.

But it will be mandatory if we reorder the parameter of send_command_ack function (I made a branch where I do so because I make protocol optional and I prefer to keep the mandatory parameter before the optional one thus protocol became the second parameter instead of the first.