### PR TITLE
Distinguish first button from the Group one

### DIFF
--- a/custom_components/rfplayer/rflib/infotypes.py
+++ b/custom_components/rfplayer/rflib/infotypes.py
@@ -72,6 +72,9 @@ def infoType_1_decode(infos:list,allowEmptyID:bool=False) -> list:
     fields_found["id"]=infos["id"]
     fields_found["command"]=fields_found["subType"]
 
+    if fields_found["command"] == "ALL_ON" or fields_found["command"] == "ALL_OFF":
+        fields_found["id"]=infos["id"]+"G"
+
     if fields_found["id"]!="0" or allowEmptyID:
         return fields_found
 


### PR DESCRIPTION
For CHACON DIO remote, the G button (the ALL one ) is sent with the same device id as the first button, but with ALL_ON or ALL_OFF a command instead of ON or OFF.

Append G to this first button id when the command is ALL_ON or ALL_OFF to uniquely identify the G button.

Fixes #10.